### PR TITLE
90 UI improvements   redesign day selector replace toggle with header navigation

### DIFF
--- a/src/app/features/dashboard/components/day-selector/day-selector.html
+++ b/src/app/features/dashboard/components/day-selector/day-selector.html
@@ -1,24 +1,33 @@
-<div class="flex justify-center">
-  <div class="inline-flex gap-1" role="tablist" aria-label="Velg dag">
-    @for (option of options; track option.value; let i = $index; let last = $last) {
-      <button
-        type="button"
-        role="tab"
-        class="min-w-[100px] border-2 px-6 py-2 text-lg font-medium leading-none transition-colors duration-150"
-        [ngClass]="[
-          i === 0 ? 'rounded-l-[10px] rounded-r-none' : '',
-          last ? 'rounded-r-[10px] rounded-l-none' : '',
-          i !== 0 && !last ? 'rounded-none' : '',
-          isSelected(option.value)
-            ? 'border-[#0B4A8B] bg-[#0B4A8B] text-white'
-            : 'border-[#0B4A8B] bg-white text-black hover:bg-blue-50',
-        ]"
-        [attr.aria-selected]="isSelected(option.value)"
-        [attr.tabindex]="isSelected(option.value) ? 0 : -1"
-        (click)="selectDay(option.value)"
-      >
-        {{ option.label }}
-      </button>
-    }
+<div class="px-4 md:px-6">
+  <div class="grid grid-cols-2 gap-2 md:gap-2" role="tablist" aria-label="Velg oversikt for dag">
+    <button
+      type="button"
+      role="tab"
+      [attr.aria-selected]="selectedDay === 'today'"
+      [attr.tabindex]="selectedDay === 'today' ? 0 : -1"
+      (click)="selectDay('today')"
+      class="flex min-h-[96px] w-full flex-col items-start justify-center rounded-xl border px-4 py-4 text-left transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0B4A8B] md:min-h-[96px] md:px-5 md:py-4"
+      [ngClass]="dayCardClasses(selectedDay === 'today')"
+    >
+      <span [ngClass]="dayTitleClasses(selectedDay === 'today')"> Dagens Oversikt </span>
+      <span [ngClass]="dayDateClasses(selectedDay === 'today')">
+        {{ todayDateLabel }}
+      </span>
+    </button>
+
+    <button
+      type="button"
+      role="tab"
+      [attr.aria-selected]="selectedDay === 'tomorrow'"
+      [attr.tabindex]="selectedDay === 'tomorrow' ? 0 : -1"
+      (click)="selectDay('tomorrow')"
+      class="flex min-h-[96px] w-full flex-col items-end justify-center rounded-xl border px-4 py-4 text-left transition-all duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0B4A8B] md:min-h-[96px] md:px-5 md:py-4"
+      [ngClass]="dayCardClasses(selectedDay === 'tomorrow')"
+    >
+      <span [ngClass]="dayTitleClasses(selectedDay === 'tomorrow')"> Morgendagens Oversikt </span>
+      <span [ngClass]="dayDateClasses(selectedDay === 'tomorrow')">
+        {{ tomorrowDateLabel }}
+      </span>
+    </button>
   </div>
 </div>

--- a/src/app/features/dashboard/components/day-selector/day-selector.spec.ts
+++ b/src/app/features/dashboard/components/day-selector/day-selector.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DaySelector } from './day-selector';
@@ -10,18 +10,11 @@ import { DayOption } from './day-selector.types';
   standalone: true,
   imports: [DaySelector],
   template: `
-    <app-day-selector
-      [selectedDay]="selectedDay"
-      [showYesterday]="showYesterday"
-      [fullWidth]="fullWidth"
-      (selectedDayChange)="onDayChange($event)"
-    />
+    <app-day-selector [selectedDay]="selectedDay" (selectedDayChange)="onDayChange($event)" />
   `,
 })
 class TestHostComponent {
   selectedDay: DayOption = 'today';
-  showYesterday = true;
-  fullWidth = true;
 
   onDayChange(day: DayOption): void {
     this.selectedDay = day;
@@ -29,58 +22,111 @@ class TestHostComponent {
 }
 
 describe('DaySelector', () => {
-  let fixture: ComponentFixture<TestHostComponent>;
-  let host: TestHostComponent;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
     }).compileComponents();
+  });
 
-    fixture = TestBed.createComponent(TestHostComponent);
-    host = fixture.componentInstance;
+  function createHost(selectedDay: DayOption = 'today') {
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const host = fixture.componentInstance;
+    host.selectedDay = selectedDay;
     fixture.detectChanges();
+    return { fixture, host };
+  }
+
+  it('should show today and tomorrow cards', () => {
+    const { fixture } = createHost();
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const texts = buttons.map((button) =>
+      button.nativeElement.textContent.replace(/\s+/g, ' ').trim(),
+    );
+
+    expect(buttons).toHaveLength(2);
+    expect(texts[0]).toContain('Dagens Oversikt torsdag 19. mars');
+    expect(texts[1]).toContain('Morgendagens Oversikt fredag 20. mars');
   });
 
-  it('should show yesterday, today and tomorrow by default', () => {
-    const buttons = fixture.debugElement.queryAll(By.css('button'));
-    const texts = buttons.map((button) => button.nativeElement.textContent.trim());
+  it('should have today selected by default', () => {
+    const { fixture } = createHost();
 
-    expect(texts).toEqual(['I går', 'I dag', 'I morgen']);
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+
+    expect(buttons[0].nativeElement.getAttribute('aria-selected')).toBe('true');
+    expect(buttons[1].nativeElement.getAttribute('aria-selected')).toBe('false');
   });
 
-  it('should mark the selected day with aria-selected=true', () => {
-    const buttons = fixture.debugElement.queryAll(By.css('button'));
-    const todayButton = buttons[1].nativeElement as HTMLButtonElement;
+  it('should mark tomorrow as selected when selectedDay is tomorrow', () => {
+    const { fixture } = createHost('tomorrow');
 
-    expect(todayButton.getAttribute('aria-selected')).toBe('true');
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+
+    expect(buttons[0].nativeElement.getAttribute('aria-selected')).toBe('false');
+    expect(buttons[1].nativeElement.getAttribute('aria-selected')).toBe('true');
   });
 
   it('should update selected day when clicking tomorrow', () => {
-    const buttons = fixture.debugElement.queryAll(By.css('button'));
-    const tomorrowButton = buttons[2];
+    const { fixture, host } = createHost('today');
 
-    tomorrowButton.triggerEventHandler('click');
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    buttons[1].triggerEventHandler('click');
+
     fixture.detectChanges();
 
     expect(host.selectedDay).toBe('tomorrow');
   });
 
-  it('should not emit or change state when clicking already selected day', () => {
-    const buttons = fixture.debugElement.queryAll(By.css('button'));
-    const todayButton = buttons[1];
+  it('should update selected day when clicking today from tomorrow', () => {
+    const { fixture, host } = createHost('tomorrow');
 
-    todayButton.triggerEventHandler('click');
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    buttons[0].triggerEventHandler('click');
+
     fixture.detectChanges();
 
     expect(host.selectedDay).toBe('today');
   });
 
-  it('should have today selected by default', () => {
+  it('should not change state when clicking already selected day', () => {
+    const { fixture, host } = createHost('today');
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    buttons[0].triggerEventHandler('click');
+
+    fixture.detectChanges();
+
+    expect(host.selectedDay).toBe('today');
+  });
+
+  it('should render a date label for both cards', () => {
+    const { fixture } = createHost();
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const texts = buttons.map((button) =>
+      button.nativeElement.textContent.replace(/\s+/g, ' ').trim(),
+    );
+
+    expect(texts[0]).toMatch(/\d{1,2}\./);
+    expect(texts[1]).toMatch(/\d{1,2}\./);
+  });
+
+  it('should apply selected styling class to today card by default', () => {
+    const { fixture } = createHost('today');
+
     const buttons = fixture.debugElement.queryAll(By.css('button'));
 
-    expect(buttons[0].nativeElement.getAttribute('aria-selected')).toBe('false');
-    expect(buttons[1].nativeElement.getAttribute('aria-selected')).toBe('true');
-    expect(buttons[2].nativeElement.getAttribute('aria-selected')).toBe('false');
+    expect(buttons[0].nativeElement.className).toContain('bg-[#EAF8FE]');
+    expect(buttons[1].nativeElement.className).toContain('bg-white');
+  });
+
+  it('should apply selected styling class to tomorrow card when selected', () => {
+    const { fixture } = createHost('tomorrow');
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+
+    expect(buttons[0].nativeElement.className).toContain('bg-white');
+    expect(buttons[1].nativeElement.className).toContain('bg-[#EAF8FE]');
   });
 });

--- a/src/app/features/dashboard/components/day-selector/day-selector.ts
+++ b/src/app/features/dashboard/components/day-selector/day-selector.ts
@@ -2,11 +2,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { NgClass } from '@angular/common';
 import { DayOption } from './day-selector.types';
 
-interface SelectorItem {
-  label: string;
-  value: DayOption;
-}
-
 @Component({
   selector: 'app-day-selector',
   standalone: true,
@@ -15,31 +10,46 @@ interface SelectorItem {
 })
 export class DaySelector {
   @Input() selectedDay: DayOption = 'today';
-  @Input() showYesterday = true;
-  @Input() fullWidth = true;
-
   @Output() selectedDayChange = new EventEmitter<DayOption>();
-
-  get options(): SelectorItem[] {
-    const items: SelectorItem[] = [];
-
-    if (this.showYesterday) {
-      items.push({ label: 'I går', value: 'yesterday' });
-    }
-
-    items.push({ label: 'I dag', value: 'today' }, { label: 'I morgen', value: 'tomorrow' });
-
-    return items;
-  }
 
   selectDay(day: DayOption): void {
     if (day === this.selectedDay) return;
-
-    this.selectedDay = day;
     this.selectedDayChange.emit(day);
   }
 
-  isSelected(day: DayOption): boolean {
-    return this.selectedDay === day;
+  get todayDateLabel(): string {
+    return this.formatDate(new Date());
+  }
+
+  get tomorrowDateLabel(): string {
+    const date = new Date();
+    date.setDate(date.getDate() + 1);
+    return this.formatDate(date);
+  }
+
+  private formatDate(date: Date): string {
+    return new Intl.DateTimeFormat('nb-NO', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+    }).format(date);
+  }
+
+  dayCardClasses(isSelected: boolean): string {
+    return isSelected
+      ? 'border-slate-500 bg-[#EAF8FE] shadow-[0_2px_8px_rgba(15,23,42,0.08)]'
+      : 'border-slate-200 bg-white shadow-none hover:border-slate-300 hover:shadow-[0_2px_8px_rgba(15,23,42,0.05)]';
+  }
+
+  dayTitleClasses(isSelected: boolean): string {
+    return isSelected
+      ? 'text-[2.2rem] font-bold leading-none tracking-[-0.02em] text-black md:text-[2.0rem]'
+      : 'text-[1.5rem] font-normal leading-tight tracking-[-0.01em] text-slate-700 md:text-[1.5rem]';
+  }
+
+  dayDateClasses(isSelected: boolean): string {
+    return isSelected
+      ? 'mt-2 text-sm font-normal text-slate-700 lowercase'
+      : 'mt-2 text-sm font-normal text-slate-700 lowercase';
   }
 }

--- a/src/app/features/dashboard/components/day-selector/day-selector.types.ts
+++ b/src/app/features/dashboard/components/day-selector/day-selector.types.ts
@@ -1,1 +1,1 @@
-export type DayOption = 'yesterday' | 'today' | 'tomorrow';
+export type DayOption = 'today' | 'tomorrow';


### PR DESCRIPTION
## 📋 Description

Redesigned the `DaySelector` component to replace the previous multi-option day toggle with a clearer two-card day switcher for **Today** and **Tomorrow**.

This update removes the old **Yesterday / Today / Tomorrow** interaction and introduces a more mobile-friendly UI where both day options are always visible as large selectable cards. Each card now displays:
- a title
- a formatted Norwegian date
- a clearer visual distinction between selected and unselected state

The goal of the change is to improve usability, reduce cognitive load, and make navigation between day views more intuitive for field technicians.

## 🔗 Related issue(s) / PR(s)

Closes: redesign of `DaySelector` / replacement of old toggle-based day navigation

Related:
- [REQ] Page – Tomorrow Overview
- [REQ] Dashboard / Today Overview
- [REQ] Reusable Component – ToggleDag (replaced / deprecated)

## 🧰 Type of change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [x] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [x] Code compiles & passes existing tests
- [x] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [x] Follows project coding style / guidelines
- [x] No new ESLint/TSLint/SwiftLint/etc. warnings
- [ ] Tested on all supported browsers / OSs / platforms

## 📝 Implementation notes

- Removed support for `yesterday` from `DayOption`
- Simplified the component API to only support `today` and `tomorrow`
- Replaced the previous segmented toggle with two large selectable cards
- Added formatted Norwegian date labels using `Intl.DateTimeFormat('nb-NO', ...)`
- Updated styling so that the selected card is visually emphasized with:
  - highlighted background
  - stronger border/shadow
  - larger and bolder title
- Reduced emphasis on the unselected card with smaller and lighter title styling
- Updated tests to reflect the new two-card design and selection behavior
- Fixed state flow so the child component emits changes without mutating its own input directly

## 📸 Screenshots / GIFs (if UI change)

<img width="460" height="493" alt="image" src="https://github.com/user-attachments/assets/2abaede3-016f-4971-b664-e1124c257974" />


## 📚 Further context

This change is based on product owner feedback that the previous toggle was less intuitive and created unnecessary cognitive load. The new design better supports quick day switching in a mobile context and aligns more closely with the intended dashboard experience for technicians.

## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀