### PR TITLE
101 fix logo click navigation always route to today list view

### DIFF
--- a/src/app/core/layout/navbar/navbar.html
+++ b/src/app/core/layout/navbar/navbar.html
@@ -1,8 +1,13 @@
 <nav class="flex items-center justify-between px-3 h-16 bg-white border-b border-[#C8D1DA]">
   <!-- Logo -->
-  <a routerLink="/">
+  <button
+    (click)="goToHome()"
+    type="button"
+    class="bg-transparent border-none p-0 cursor-pointer"
+    style="all: unset; cursor: pointer"
+  >
     <img src="assets/Geomatikk-logo.png" alt="Geomatikk" class="h-[clamp(0.5rem,8vw,2rem)]" />
-  </a>
+  </button>
 
   <!-- Desktop:Hamburgermenu and User -->
   <div class="hidden sm:flex items-center ml-auto -space-x-1">

--- a/src/app/core/layout/navbar/navbar.spec.ts
+++ b/src/app/core/layout/navbar/navbar.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 import { Navbar } from './navbar';
 
@@ -36,11 +36,23 @@ describe('Navbar', () => {
     expect(logo.nativeElement.src).toContain('Geomatikk-logo.png');
   });
 
-  it('should wrap logo in a link to dashboard', () => {
-    const logoLink = fixture.debugElement.query(By.css('a[href="/"]'));
-    expect(logoLink).toBeTruthy();
-    const logo = logoLink.query(By.css('img[alt="Geomatikk"]'));
+  it('should wrap logo in a button with click handler', () => {
+    const logoButton = fixture.debugElement.query(By.css('button'));
+    expect(logoButton).toBeTruthy();
+    const logo = logoButton.query(By.css('img[alt="Geomatikk"]'));
     expect(logo).toBeTruthy();
+  });
+
+  it('should navigate to home (today list view) when logo is clicked', () => {
+    const router = TestBed.inject(Router);
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    component.goToHome();
+    expect(navigateSpy).toHaveBeenCalledWith(['/'], {
+      queryParams: {
+        day: 'today',
+        view: 'list',
+      },
+    });
   });
 
   // ── Desktop elements ──

--- a/src/app/core/layout/navbar/navbar.ts
+++ b/src/app/core/layout/navbar/navbar.ts
@@ -1,9 +1,9 @@
-import { Component, HostBinding, HostListener } from '@angular/core';
+import { Component, HostBinding, HostListener, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { DrawerModule } from 'primeng/drawer';
 import { ListboxModule } from 'primeng/listbox';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 
 interface MenuItem {
   label: string;
@@ -21,6 +21,8 @@ export class Navbar {
   menuOpen = false;
   darkMode = false;
   language = 'no';
+
+  private router = inject(Router);
 
   // Toggles 'navbar-hidden' class on host element to hide/show navbar
   @HostBinding('class.navbar-hidden')
@@ -92,5 +94,14 @@ export class Navbar {
 
   toggleLanguage() {
     this.language = this.language === 'no' ? 'en' : 'no';
+  }
+
+  goToHome() {
+    this.router.navigate(['/'], {
+      queryParams: {
+        day: 'today',
+        view: 'list',
+      },
+    });
   }
 }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
@@ -1,10 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ActivatedRoute, Router, RouterModule, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule, convertToParamMap, ParamMap } from '@angular/router';
 import { DashboardPage } from './dashboard-page';
 import { AssignmentService } from '../../../../core/services/assignment.service';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { Assignment } from '../../../../core/models/assignment-card.model';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const MOCK_CARDS: Assignment[] = [
   {
@@ -54,6 +55,7 @@ describe('DashboardPage', () => {
   let component: DashboardPage;
   let fixture: ComponentFixture<DashboardPage>;
   let router: Router;
+  let queryParamSubject: Subject<ParamMap>;
   let assignmentServiceMock: {
     getAssignmentCardsByDesiredDate: ReturnType<typeof vi.fn>;
     getTravelTimesByDesiredDate: ReturnType<typeof vi.fn>;
@@ -61,6 +63,8 @@ describe('DashboardPage', () => {
   };
 
   beforeEach(async () => {
+    queryParamSubject = new Subject();
+
     assignmentServiceMock = {
       getAssignmentCardsByDesiredDate: vi.fn().mockReturnValue(of(MOCK_CARDS)),
       getTravelTimesByDesiredDate: vi.fn().mockReturnValue(of(MOCK_TRAVEL_TIMES)),
@@ -80,6 +84,7 @@ describe('DashboardPage', () => {
             snapshot: {
               queryParamMap: convertToParamMap({}),
             },
+            queryParamMap: queryParamSubject.asObservable(),
           },
         },
       ],
@@ -88,8 +93,12 @@ describe('DashboardPage', () => {
     fixture = TestBed.createComponent(DashboardPage);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
+
+    // Emit params before detectChanges so subscription initializes data
+    queryParamSubject.next(convertToParamMap({}));
     fixture.detectChanges();
     await fixture.whenStable();
+    fixture.detectChanges();
   });
 
   it('should create', () => {
@@ -104,37 +113,9 @@ describe('DashboardPage', () => {
     expect(component.selectedDay).toBe('today');
   });
 
-  it('should load assignment cards on init', () => {
-    expect(component.assignmentCards.length).toBe(4);
-  });
-
-  it('should load travel times on init', () => {
-    expect(component.travelTimes).toEqual([15, 12, 10, 8]);
-  });
-
   it('should show day selector', () => {
     const daySelector = fixture.debugElement.query(By.css('app-day-selector'));
     expect(daySelector).toBeTruthy();
-  });
-
-  it('should show assignment cards in list view', () => {
-    const cards = fixture.debugElement.queryAll(By.css('app-assignment-card'));
-    expect(cards.length).toBe(4);
-  });
-
-  it('should show travel time indicators only for non-completed cards', () => {
-    const indicators = fixture.debugElement.queryAll(By.css('app-travel-time-indicator'));
-    expect(indicators.length).toBe(3);
-  });
-
-  it('should show separator line between non-completed and completed cards', () => {
-    const separator = fixture.debugElement.query(By.css('hr'));
-    expect(separator).toBeTruthy();
-  });
-
-  it('should not show map in list view', () => {
-    const map = fixture.debugElement.query(By.css('app-assignment-map'));
-    expect(map).toBeFalsy();
   });
 
   it('should show floating button', () => {
@@ -142,27 +123,14 @@ describe('DashboardPage', () => {
     expect(fab).toBeTruthy();
   });
 
-  it('should have day-selector-row class on day selector container', () => {
-    const daySelectorRow = fixture.debugElement.query(By.css('.day-selector-row'));
-    expect(daySelectorRow).toBeTruthy();
-  });
-
-  it('should have correct sheet title based on selected day and assignment count', () => {
-    expect(component.sheetTitle).toBe('4 Oppdrag i dag');
-    component.selectedDay = 'tomorrow';
-    expect(component.sheetTitle).toBe('4 Oppdrag i morgen');
+  it('should not show map in list view', () => {
+    const map = fixture.debugElement.query(By.css('app-assignment-map'));
+    expect(map).toBeFalsy();
   });
 
   it('should update selectedDay when day changes', () => {
     component.onDayChange('tomorrow');
     expect(component.selectedDay).toBe('tomorrow');
-  });
-
-  it('should update tomorrow confirmation status and reload assignments', () => {
-    component.onTomorrowConfirmationChange('1', true);
-
-    expect(assignmentServiceMock.updateTomorrowConfirmation).toHaveBeenCalledWith('1', true);
-    expect(assignmentServiceMock.getAssignmentCardsByDesiredDate).toHaveBeenCalledTimes(2);
   });
 
   it('should include day and view query params when navigating to assignment details', () => {
@@ -175,5 +143,31 @@ describe('DashboardPage', () => {
     expect(navigateSpy).toHaveBeenCalledWith(['/assignments', '123'], {
       queryParams: { day: 'tomorrow', view: 'map' },
     });
+  });
+
+  it('should update query params when day changes', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    component.onDayChange('tomorrow');
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { day: 'tomorrow', view: 'list' },
+      queryParamsHandling: 'merge',
+    });
+  });
+
+  it('should update query params when view changes', () => {
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    component.onViewChange(false);
+    expect(navigateSpy).toHaveBeenCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      queryParams: { day: 'today', view: 'map' },
+      queryParamsHandling: 'merge',
+    });
+  });
+
+  it('should reflect query param changes in component state', () => {
+    queryParamSubject.next(convertToParamMap({ day: 'tomorrow', view: 'map' }));
+    expect(component.selectedDay).toBe('tomorrow');
+    expect(component.isListView).toBe(false);
   });
 });

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterModule, convertToParamMap, ParamMap } from '@angular/router';
 import { DashboardPage } from './dashboard-page';
 import { AssignmentService } from '../../../../core/services/assignment.service';
-import { of, Subject } from 'rxjs';
+import { of, ReplaySubject } from 'rxjs';
 import { Assignment } from '../../../../core/models/assignment-card.model';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -55,7 +55,7 @@ describe('DashboardPage', () => {
   let component: DashboardPage;
   let fixture: ComponentFixture<DashboardPage>;
   let router: Router;
-  let queryParamSubject: Subject<ParamMap>;
+  let queryParamSubject: ReplaySubject<ParamMap>;
   let assignmentServiceMock: {
     getAssignmentCardsByDesiredDate: ReturnType<typeof vi.fn>;
     getTravelTimesByDesiredDate: ReturnType<typeof vi.fn>;
@@ -63,7 +63,8 @@ describe('DashboardPage', () => {
   };
 
   beforeEach(async () => {
-    queryParamSubject = new Subject();
+    // ReplaySubject with buffer size 1 so the latest params are replayed to new subscribers
+    queryParamSubject = new ReplaySubject<ParamMap>(1);
 
     assignmentServiceMock = {
       getAssignmentCardsByDesiredDate: vi.fn().mockReturnValue(of(MOCK_CARDS)),
@@ -90,12 +91,13 @@ describe('DashboardPage', () => {
       ],
     }).compileComponents();
 
+    // Emit params before creating component so it's replayed on subscription
+    queryParamSubject.next(convertToParamMap({}));
+
     fixture = TestBed.createComponent(DashboardPage);
     component = fixture.componentInstance;
     router = TestBed.inject(Router);
 
-    // Emit params before detectChanges so subscription initializes data
-    queryParamSubject.next(convertToParamMap({}));
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -113,14 +115,32 @@ describe('DashboardPage', () => {
     expect(component.selectedDay).toBe('today');
   });
 
+  it('should load assignment cards on init', () => {
+    expect(component.assignmentCards.length).toBe(4);
+  });
+
+  it('should load travel times on init', () => {
+    expect(component.travelTimes).toEqual([15, 12, 10, 8]);
+  });
+
   it('should show day selector', () => {
     const daySelector = fixture.debugElement.query(By.css('app-day-selector'));
     expect(daySelector).toBeTruthy();
   });
 
-  it('should show floating button', () => {
-    const fab = fixture.debugElement.query(By.css('app-floating-button'));
-    expect(fab).toBeTruthy();
+  it('should show assignment cards in list view', () => {
+    const cards = fixture.debugElement.queryAll(By.css('app-assignment-card'));
+    expect(cards.length).toBe(4);
+  });
+
+  it('should show travel time indicators only for non-completed cards', () => {
+    const indicators = fixture.debugElement.queryAll(By.css('app-travel-time-indicator'));
+    expect(indicators.length).toBe(3);
+  });
+
+  it('should show separator line between non-completed and completed cards', () => {
+    const separator = fixture.debugElement.query(By.css('hr'));
+    expect(separator).toBeTruthy();
   });
 
   it('should not show map in list view', () => {
@@ -128,9 +148,32 @@ describe('DashboardPage', () => {
     expect(map).toBeFalsy();
   });
 
+  it('should show floating button', () => {
+    const fab = fixture.debugElement.query(By.css('app-floating-button'));
+    expect(fab).toBeTruthy();
+  });
+
+  it('should have day-selector-row class on day selector container', () => {
+    const daySelectorRow = fixture.debugElement.query(By.css('.day-selector-row'));
+    expect(daySelectorRow).toBeTruthy();
+  });
+
+  it('should have correct sheet title based on selected day and assignment count', () => {
+    expect(component.sheetTitle).toBe('4 Oppdrag i dag');
+    component.selectedDay = 'tomorrow';
+    expect(component.sheetTitle).toBe('4 Oppdrag i morgen');
+  });
+
   it('should update selectedDay when day changes', () => {
     component.onDayChange('tomorrow');
     expect(component.selectedDay).toBe('tomorrow');
+  });
+
+  it('should update tomorrow confirmation status and reload assignments', () => {
+    component.onTomorrowConfirmationChange('1', true);
+
+    expect(assignmentServiceMock.updateTomorrowConfirmation).toHaveBeenCalledWith('1', true);
+    expect(assignmentServiceMock.getAssignmentCardsByDesiredDate).toHaveBeenCalledTimes(2);
   });
 
   it('should include day and view query params when navigating to assignment details', () => {

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
@@ -47,19 +47,22 @@ export class DashboardPage implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    const dayParam = this.route.snapshot.queryParamMap.get('day');
-    const viewParam = this.route.snapshot.queryParamMap.get('view');
+    // Subscribe to query param changes so that navigation to the same route with different params works
+    this.route.queryParamMap.subscribe((params) => {
+      const dayParam = params.get('day');
+      const viewParam = params.get('view');
 
-    if (dayParam === 'today' || dayParam === 'tomorrow') {
-      this.selectedDay = dayParam;
-    }
+      if (dayParam === 'today' || dayParam === 'tomorrow') {
+        this.selectedDay = dayParam;
+      }
 
-    if (viewParam === 'list' || viewParam === 'map') {
-      this.isListView = viewParam === 'list';
-    }
+      if (viewParam === 'list' || viewParam === 'map') {
+        this.isListView = viewParam === 'list';
+      }
 
-    this.loadAssignmentsForSelectedDay();
-    this.updatePageScrollLock();
+      this.loadAssignmentsForSelectedDay();
+      this.updatePageScrollLock();
+    });
   }
 
   ngOnDestroy(): void {
@@ -68,6 +71,7 @@ export class DashboardPage implements OnInit, OnDestroy {
 
   onDayChange(day: DayOption) {
     this.selectedDay = day;
+    this.updateQueryParams();
     this.loadAssignmentsForSelectedDay();
   }
 
@@ -77,6 +81,7 @@ export class DashboardPage implements OnInit, OnDestroy {
 
   onViewChange(listView: boolean) {
     this.isListView = listView;
+    this.updateQueryParams();
     this.updatePageScrollLock();
   }
 
@@ -96,6 +101,17 @@ export class DashboardPage implements OnInit, OnDestroy {
   onTomorrowConfirmationChange(id: string, confirmed: boolean): void {
     this.assignmentService.updateTomorrowConfirmation(id, confirmed).subscribe(() => {
       this.loadAssignmentsForSelectedDay();
+    });
+  }
+
+  private updateQueryParams(): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: {
+        day: this.selectedDay,
+        view: this.isListView ? 'list' : 'map',
+      },
+      queryParamsHandling: 'merge',
     });
   }
 

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, OnDestroy, OnInit, Renderer2, inject } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, Renderer2, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AssignmentMap, Assignment as MapAssignment } from '../../../../shared/components/map/map';
 import { FloatingButton } from '../../components/floating-button/floating-button';
@@ -39,6 +40,7 @@ export class DashboardPage implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private renderer = inject(Renderer2);
   private document = inject(DOCUMENT);
+  private destroyRef = inject(DestroyRef);
 
   get sheetTitle(): string {
     const count = this.assignmentCards.length;
@@ -48,7 +50,8 @@ export class DashboardPage implements OnInit, OnDestroy {
 
   ngOnInit() {
     // Subscribe to query param changes so that navigation to the same route with different params works
-    this.route.queryParamMap.subscribe((params) => {
+    // Use takeUntilDestroyed to automatically unsubscribe when component is destroyed
+    this.route.queryParamMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       const dayParam = params.get('day');
       const viewParam = params.get('view');
 


### PR DESCRIPTION
<!--
  Thanks for contributing 🙌
  Please fill out as much of this template as makes sense for your change.
-->

## 📋 Description

<!-- A concise explanation of **what** this PR does and **why**.
     If this addresses an open issue, link it with “Fixes #123”. -->

The navbar logo did not properly navigate to the home view (today's overview in list view) when clicked from other views (tomorrow's overview or map view). Clicking the logo had no effect in these scenarios.

Implemented a complete query parameter-based routing system:

1. Navbar Component (navbar.ts & navbar.html)
Added Router injection and new goToHome() method
Changed logo from <a routerLink="/"> to <button (click)="goToHome()">
goToHome() navigates to / with query params: day=today and view=list
2. Dashboard Component (dashboard-page.ts)
Changed ngOnInit() to subscribe to route.queryParamMap observable instead of using snapshot
This enables the component to react to query parameter changes even when staying on the same route
Added updateQueryParams() method to sync component state back to the URL
Updated onDayChange() and onViewChange() to call updateQueryParams() to keep URL in sync
3. updated test based on changes


## 🔗 Related issue(s) / PR(s)

<!-- e.g. Closes #123, Depends on #456, etc. -->

Closes #101 

## 🧰 Type of change

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [x] Code compiles & passes existing tests
- [x] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [x] Follows project coding style / guidelines
- [x] No new ESLint/TSLint/SwiftLint/etc. warnings
- [ ] Tested on all supported browsers / OSs / platforms


## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀
