### PR TITLE
52 map interactions focus marker open details show directions

### DIFF
--- a/src/app/features/dashboard/components/map-bottom-sheet/map-bottom-sheet.spec.ts
+++ b/src/app/features/dashboard/components/map-bottom-sheet/map-bottom-sheet.spec.ts
@@ -4,6 +4,13 @@ import { MapBottomSheet } from './map-bottom-sheet';
 
 describe('MapBottomSheet', () => {
   let component: MapBottomSheet;
+  let mockContentElement: {
+    scrollTop: number;
+    clientHeight: number;
+    scrollHeight: number;
+    scrollTo: ReturnType<typeof vi.fn>;
+    getBoundingClientRect: () => { top: number; height: number };
+  };
 
   const setPointerCapture = vi.fn();
   const releasePointerCapture = vi.fn();
@@ -19,8 +26,15 @@ describe('MapBottomSheet', () => {
       }),
     };
 
-    const mockContentElement = {
+    mockContentElement = {
       scrollTop: 0,
+      clientHeight: 400,
+      scrollHeight: 1200,
+      scrollTo: vi.fn(),
+      getBoundingClientRect: () => ({
+        top: 100,
+        height: 400,
+      }),
     };
 
     component.sheetRef = {
@@ -36,6 +50,7 @@ describe('MapBottomSheet', () => {
     vi.restoreAllMocks();
     setPointerCapture.mockReset();
     releasePointerCapture.mockReset();
+    mockContentElement.scrollTo.mockReset();
   });
 
   it('should create', () => {
@@ -254,5 +269,73 @@ describe('MapBottomSheet', () => {
     } as PointerEvent);
 
     expect(component.contentRef.nativeElement.scrollTop).toBe(0);
+  });
+
+  it('should allow programmatic snapping to peek', () => {
+    const emitSpy = vi.spyOn(component.snapChanged, 'emit');
+
+    component.ngOnInit();
+    component.currentSnap = 'collapsed';
+    component.currentTranslateY = 844;
+
+    component.snapTo('peek');
+
+    expect(component.currentSnap).toBe('peek');
+    expect(component.currentTranslateY).toBe(520);
+    expect(emitSpy).toHaveBeenCalledWith('peek');
+  });
+
+  it('should scroll only the sheet content to a target element', () => {
+    component.ngOnInit();
+
+    const targetElement = {
+      getBoundingClientRect: () => ({
+        top: 340,
+        height: 120,
+      }),
+    } as HTMLElement;
+
+    component.scrollToElement(targetElement);
+
+    expect(component.contentRef.nativeElement.scrollTo).toHaveBeenCalledWith({
+      top: 240,
+      behavior: 'smooth',
+    });
+  });
+
+  it('should clamp scroll-to-element to the top of the list', () => {
+    component.ngOnInit();
+
+    const targetElement = {
+      getBoundingClientRect: () => ({
+        top: 80,
+        height: 120,
+      }),
+    } as HTMLElement;
+
+    component.scrollToElement(targetElement);
+
+    expect(component.contentRef.nativeElement.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('should clamp scroll-to-element to the bottom of the list', () => {
+    component.ngOnInit();
+
+    const targetElement = {
+      getBoundingClientRect: () => ({
+        top: 1140,
+        height: 120,
+      }),
+    } as HTMLElement;
+
+    component.scrollToElement(targetElement);
+
+    expect(component.contentRef.nativeElement.scrollTo).toHaveBeenCalledWith({
+      top: 800,
+      behavior: 'smooth',
+    });
   });
 });

--- a/src/app/features/dashboard/components/map-bottom-sheet/map-bottom-sheet.ts
+++ b/src/app/features/dashboard/components/map-bottom-sheet/map-bottom-sheet.ts
@@ -10,7 +10,11 @@ import {
   AfterViewInit,
 } from '@angular/core';
 
-type SnapPoint = 'collapsed' | 'peek' | 'expanded';
+export type SnapPoint = 'collapsed' | 'peek' | 'expanded';
+
+export const MAP_BOTTOM_SHEET_EXPANDED_RATIO = 0.1;
+export const MAP_BOTTOM_SHEET_PEEK_RATIO = 0.52;
+export const MAP_BOTTOM_SHEET_COLLAPSED_VISIBLE_HEIGHT = 156;
 
 @Component({
   selector: 'app-map-bottom-sheet',
@@ -90,7 +94,7 @@ export class MapBottomSheet implements OnInit, AfterViewInit {
     this.snapTo(nearest);
   }
 
-  private snapTo(point: SnapPoint, emit = true): void {
+  snapTo(point: SnapPoint, emit = true): void {
     this.currentSnap = point;
     this.currentTranslateY = this.snapPoints[point];
 
@@ -103,13 +107,30 @@ export class MapBottomSheet implements OnInit, AfterViewInit {
     }
   }
 
+  scrollToElement(element: HTMLElement, behavior: ScrollBehavior = 'smooth'): void {
+    const contentElement = this.contentRef?.nativeElement;
+    if (!contentElement) {
+      return;
+    }
+
+    const contentRect = contentElement.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const elementTop = elementRect.top - contentRect.top + contentElement.scrollTop;
+    const maxScrollTop = Math.max(0, contentElement.scrollHeight - contentElement.clientHeight);
+    const targetTop = this.clamp(elementTop, 0, maxScrollTop);
+
+    contentElement.scrollTo({
+      top: targetTop,
+      behavior,
+    });
+  }
+
   private calculateSnapPoints(): void {
     const sheetHeight =
       this.sheetRef?.nativeElement?.getBoundingClientRect().height || window.innerHeight;
-    const collapsedVisibleHeight = 156;
-    const collapsed = Math.max(0, sheetHeight - collapsedVisibleHeight);
-    const expanded = sheetHeight * 0.1;
-    const peekRaw = sheetHeight * 0.52;
+    const collapsed = Math.max(0, sheetHeight - MAP_BOTTOM_SHEET_COLLAPSED_VISIBLE_HEIGHT);
+    const expanded = sheetHeight * MAP_BOTTOM_SHEET_EXPANDED_RATIO;
+    const peekRaw = sheetHeight * MAP_BOTTOM_SHEET_PEEK_RATIO;
 
     this.snapPoints = {
       expanded,

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.css
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.css
@@ -40,3 +40,39 @@
   display: block;
   height: 100%;
 }
+
+.mini-assignment-card-row {
+  border-radius: 1.5rem;
+  padding: 0.375rem 0.25rem;
+  scroll-margin-top: 1rem;
+  scroll-margin-bottom: 12rem;
+}
+
+.mini-assignment-card-row.marker-focused {
+  box-shadow:
+    0 0 0 3px rgba(84, 127, 169, 0.34),
+    0 16px 32px rgba(31, 78, 121, 0.14);
+  transform: translateY(-2px) scale(1.01);
+  animation: marker-card-focus-in 720ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes marker-card-focus-in {
+  0% {
+    box-shadow: 0 0 0 0 rgba(84, 127, 169, 0);
+    transform: translateY(0) scale(1);
+  }
+
+  65% {
+    box-shadow:
+      0 0 0 5px rgba(84, 127, 169, 0.22),
+      0 20px 36px rgba(31, 78, 121, 0.18);
+    transform: translateY(-3px) scale(1.015);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 3px rgba(84, 127, 169, 0.34),
+      0 16px 32px rgba(31, 78, 121, 0.14);
+    transform: translateY(-2px) scale(1.01);
+  }
+}

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.html
@@ -42,10 +42,16 @@
             @if (travelTimes[i] !== undefined) {
               <app-travel-time-indicator [travelTimeMinutes]="travelTimes[i]" />
             }
-            <app-mini-assignment-card
-              [assignment]="assignment"
-              (cardClick)="goToAssignmentDetails($event)"
-            />
+            <div
+              #miniAssignmentCardRow
+              class="mini-assignment-card-row"
+              [attr.data-assignment-id]="assignment.id"
+            >
+              <app-mini-assignment-card
+                [assignment]="assignment"
+                (cardClick)="goToAssignmentDetails($event)"
+              />
+            </div>
           }
         </div>
       </app-map-bottom-sheet>

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
@@ -2,13 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ActivatedRoute, RouterModule, convertToParamMap, ParamMap } from '@angular/router';
 import { of, ReplaySubject } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DashboardPage } from './dashboard-page';
 import { AssignmentService } from '../../../../core/services/assignment.service';
 import { Assignment } from '../../../../core/models/assignment-card.model';
 import { DailyProgressSummary } from '../../../../core/models/daily-progress.model';
 import { DailyProgressInfobox } from '../../components/daily-progress-infobox/daily-progress-infobox';
+import { MAP_BOTTOM_SHEET_PEEK_RATIO } from '../../components/map-bottom-sheet/map-bottom-sheet';
 
 const MOCK_CARDS: Assignment[] = [
   {
@@ -76,6 +77,11 @@ describe('DashboardPage', () => {
     getDailyProgressByDesiredDate: ReturnType<typeof vi.fn>;
     updateTomorrowConfirmation: ReturnType<typeof vi.fn>;
   };
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
   beforeEach(async () => {
     queryParamSubject = new ReplaySubject<ParamMap>(1);
@@ -172,5 +178,85 @@ describe('DashboardPage', () => {
 
     const tomorrowInfobox = tomorrowFixture.debugElement.query(By.directive(DailyProgressInfobox));
     expect(tomorrowInfobox.componentInstance.day).toBe('tomorrow');
+  });
+
+  it('should focus the map, snap the sheet, and highlight the matching card when a marker is clicked', () => {
+    vi.useFakeTimers();
+    component.isListView = false;
+
+    const markerAssignment = {
+      id: '2',
+      name: 'Neste oppdrag',
+      location: { lat: 63.4305, lon: 10.3951 },
+    };
+    const focusAssignment = vi.fn();
+    const snapTo = vi.fn();
+    const scrollToElement = vi.fn();
+    const cardRow = document.createElement('div');
+    cardRow.dataset['assignmentId'] = '2';
+
+    (component as unknown as Record<string, unknown>)['assignmentMap'] = {
+      focusAssignment,
+    };
+    (component as unknown as Record<string, unknown>)['mapBottomSheet'] = {
+      snapTo,
+      scrollToElement,
+    };
+    (component as unknown as Record<string, unknown>)['miniAssignmentCardRows'] = {
+      find: (predicate: (row: { nativeElement: HTMLElement }) => boolean) => {
+        const row = { nativeElement: cardRow };
+        return predicate(row) ? row : undefined;
+      },
+    };
+
+    component.onMarkerClicked(markerAssignment);
+
+    expect(focusAssignment).toHaveBeenCalledWith(
+      markerAssignment,
+      expect.objectContaining({
+        targetYRatio: MAP_BOTTOM_SHEET_PEEK_RATIO / 2,
+      }),
+    );
+    expect(snapTo).toHaveBeenCalledWith('peek');
+    expect(scrollToElement).not.toHaveBeenCalled();
+    expect(cardRow.classList.contains('marker-focused')).toBe(false);
+
+    vi.advanceTimersByTime(280);
+
+    expect(scrollToElement).toHaveBeenCalledWith(cardRow);
+    expect(cardRow.classList.contains('marker-focused')).toBe(false);
+
+    vi.advanceTimersByTime(180);
+
+    expect(cardRow.classList.contains('marker-focused')).toBe(true);
+  });
+
+  it('should clear the highlighted card on the next user interaction', () => {
+    vi.useFakeTimers();
+    component.isListView = false;
+
+    const cardRow = document.createElement('div');
+    cardRow.dataset['assignmentId'] = '2';
+
+    (component as unknown as Record<string, unknown>)['miniAssignmentCardRows'] = {
+      find: (predicate: (row: { nativeElement: HTMLElement }) => boolean) => {
+        const row = { nativeElement: cardRow };
+        return predicate(row) ? row : undefined;
+      },
+    };
+
+    component.onMarkerClicked({
+      id: '2',
+      name: 'Neste oppdrag',
+      location: { lat: 63.4305, lon: 10.3951 },
+    });
+
+    vi.advanceTimersByTime(460);
+
+    expect(cardRow.classList.contains('marker-focused')).toBe(true);
+
+    component.onUserInteractionStart();
+
+    expect(cardRow.classList.contains('marker-focused')).toBe(false);
   });
 });

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
@@ -1,5 +1,17 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, DestroyRef, OnDestroy, OnInit, Renderer2, inject } from '@angular/core';
+import {
+  Component,
+  DestroyRef,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  Renderer2,
+  ViewChild,
+  ViewChildren,
+  inject,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AssignmentMap, Assignment as MapAssignment } from '../../../../shared/components/map/map';
@@ -14,9 +26,14 @@ import {
 } from '../../../../core/models/daily-progress.model';
 import { AssignmentService } from '../../../../core/services/assignment.service';
 import { MapBottomSheet } from '../../components/map-bottom-sheet/map-bottom-sheet';
+import { MAP_BOTTOM_SHEET_PEEK_RATIO } from '../../components/map-bottom-sheet/map-bottom-sheet';
 import { TravelTimeIndicator } from '../../components/travel-time-indicator/travel-time-indicator';
 import { MiniAssignmentCard } from '../../components/mini-assignment-card/mini-assignment-card';
 import { DailyProgressInfobox } from '../../components/daily-progress-infobox/daily-progress-infobox';
+
+const MAP_MARKER_FOCUS_TARGET_Y_RATIO = MAP_BOTTOM_SHEET_PEEK_RATIO / 2;
+const MAP_BOTTOM_SHEET_SCROLL_DELAY_MS = 280;
+const CARD_HIGHLIGHT_DELAY_AFTER_SCROLL_MS = 180;
 
 @Component({
   selector: 'app-dashboard-page',
@@ -35,6 +52,11 @@ import { DailyProgressInfobox } from '../../components/daily-progress-infobox/da
   styleUrl: './dashboard-page.css',
 })
 export class DashboardPage implements OnInit, OnDestroy {
+  @ViewChild(AssignmentMap) private assignmentMap?: AssignmentMap;
+  @ViewChild(MapBottomSheet) private mapBottomSheet?: MapBottomSheet;
+  @ViewChildren('miniAssignmentCardRow', { read: ElementRef })
+  private miniAssignmentCardRows?: QueryList<ElementRef<HTMLElement>>;
+
   selectedDay: DayOption = 'today';
   isListView = true;
   assignmentCards: Assignment[] = [];
@@ -48,6 +70,9 @@ export class DashboardPage implements OnInit, OnDestroy {
   private renderer = inject(Renderer2);
   private document = inject(DOCUMENT);
   private destroyRef = inject(DestroyRef);
+  private highlightedCardElement?: HTMLElement;
+  private pendingCardScrollTimeoutId?: ReturnType<typeof setTimeout>;
+  private pendingCardHighlightTimeoutId?: ReturnType<typeof setTimeout>;
 
   get sheetTitle(): string {
     const count = this.assignmentCards.length;
@@ -74,6 +99,9 @@ export class DashboardPage implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.clearPendingCardScroll();
+    this.clearPendingCardHighlight();
+    this.clearMarkerCardFocus();
     this.unlockPageScroll();
   }
 
@@ -84,17 +112,39 @@ export class DashboardPage implements OnInit, OnDestroy {
   }
 
   onMarkerClicked(assignment: MapAssignment) {
-    console.log('Marker clicked:', assignment);
+    if (this.isListView) {
+      return;
+    }
+
+    const assignmentId = String(assignment.id);
+    this.assignmentMap?.focusAssignment(assignment, {
+      targetYRatio: MAP_MARKER_FOCUS_TARGET_Y_RATIO,
+    });
+    this.mapBottomSheet?.snapTo('peek');
+    this.scrollToAssignmentCard(assignmentId);
   }
 
   onViewChange(listView: boolean) {
     this.isListView = listView;
+    if (listView) {
+      this.clearPendingCardScroll();
+      this.clearPendingCardHighlight();
+      this.clearMarkerCardFocus();
+    }
     this.updateQueryParams();
     this.updatePageScrollLock();
   }
 
   onSnapChanged(snap: 'collapsed' | 'peek' | 'expanded') {
     console.log('Bottom sheet snap:', snap);
+  }
+
+  @HostListener('document:pointerdown')
+  @HostListener('document:wheel')
+  onUserInteractionStart(): void {
+    this.clearPendingCardScroll();
+    this.clearPendingCardHighlight();
+    this.clearMarkerCardFocus();
   }
 
   goToAssignmentDetails(id: string): void {
@@ -156,6 +206,9 @@ export class DashboardPage implements OnInit, OnDestroy {
   }
 
   private loadAssignmentsForSelectedDay(): void {
+    this.clearPendingCardScroll();
+    this.clearPendingCardHighlight();
+    this.clearMarkerCardFocus();
     const date = this.getDateForDay(this.selectedDay);
 
     this.assignmentService.getAssignmentCardsByDesiredDate(date).subscribe((cards) => {
@@ -163,7 +216,7 @@ export class DashboardPage implements OnInit, OnDestroy {
       this.mapAssignments = cards
         .filter((card) => card.locationPoint)
         .map((card) => ({
-          id: Number(card.id),
+          id: card.id,
           name: card.title,
           location: {
             lat: card.locationPoint!.y,
@@ -180,5 +233,71 @@ export class DashboardPage implements OnInit, OnDestroy {
     this.assignmentService.getDailyProgressByDesiredDate(date).subscribe((progress) => {
       this.dailyProgress = progress;
     });
+  }
+
+  private scrollToAssignmentCard(assignmentId: string): void {
+    this.clearPendingCardScroll();
+    this.clearPendingCardHighlight();
+    this.pendingCardScrollTimeoutId = window.setTimeout(() => {
+      const cardElement = this.findAssignmentCardRow(assignmentId);
+      if (!cardElement) {
+        this.pendingCardScrollTimeoutId = undefined;
+        return;
+      }
+
+      this.mapBottomSheet?.scrollToElement(cardElement);
+      this.pendingCardScrollTimeoutId = undefined;
+      this.pendingCardHighlightTimeoutId = window.setTimeout(() => {
+        this.highlightAssignmentCard(assignmentId);
+        this.pendingCardHighlightTimeoutId = undefined;
+      }, CARD_HIGHLIGHT_DELAY_AFTER_SCROLL_MS);
+    }, MAP_BOTTOM_SHEET_SCROLL_DELAY_MS);
+  }
+
+  private highlightAssignmentCard(assignmentId: string): void {
+    const cardElement = this.findAssignmentCardRow(assignmentId);
+    if (!cardElement) {
+      return;
+    }
+
+    this.clearMarkerCardFocus();
+
+    // Force a reflow so the focus animation restarts when the same marker is tapped again.
+    void cardElement.offsetWidth;
+    cardElement.classList.add('marker-focused');
+    this.highlightedCardElement = cardElement;
+  }
+
+  private findAssignmentCardRow(assignmentId: string): HTMLElement | undefined {
+    return this.miniAssignmentCardRows?.find(
+      (row) => row.nativeElement.dataset['assignmentId'] === assignmentId,
+    )?.nativeElement;
+  }
+
+  private clearMarkerCardFocus(): void {
+    if (!this.highlightedCardElement) {
+      return;
+    }
+
+    this.highlightedCardElement.classList.remove('marker-focused');
+    this.highlightedCardElement = undefined;
+  }
+
+  private clearPendingCardScroll(): void {
+    if (!this.pendingCardScrollTimeoutId) {
+      return;
+    }
+
+    clearTimeout(this.pendingCardScrollTimeoutId);
+    this.pendingCardScrollTimeoutId = undefined;
+  }
+
+  private clearPendingCardHighlight(): void {
+    if (!this.pendingCardHighlightTimeoutId) {
+      return;
+    }
+
+    clearTimeout(this.pendingCardHighlightTimeoutId);
+    this.pendingCardHighlightTimeoutId = undefined;
   }
 }

--- a/src/app/shared/components/map/map.ts
+++ b/src/app/shared/components/map/map.ts
@@ -25,10 +25,17 @@ import Style from 'ol/style/Style';
 import { ThemeService } from '../../../core/services/theme.service';
 
 export interface Assignment {
-  id: number;
+  id: string | number;
   name: string;
   location?: { lat?: number | null; lon?: number | null } | null;
   description?: string;
+}
+
+interface FocusAssignmentOptions {
+  zoom?: number;
+  duration?: number;
+  targetXRatio?: number;
+  targetYRatio?: number;
 }
 
 @Component({
@@ -164,6 +171,47 @@ export class AssignmentMap implements AfterViewInit, OnDestroy, OnChanges {
     this.tileLayer.setSource(newSource);
   }
 
+  focusAssignment(assignment: Assignment, options: FocusAssignmentOptions = {}): void {
+    if (!this.map || !this.hasValidCoordinates(assignment)) {
+      return;
+    }
+
+    const location = assignment.location as { lat: number; lon: number };
+    const size = this.map.getSize();
+    if (!size) {
+      return;
+    }
+
+    const view = this.map.getView();
+    const currentCenter = view.getCenter();
+    const currentZoom = view.getZoom();
+    const nextZoom = Math.max(currentZoom ?? 0, options.zoom ?? (this.compact ? 14 : 16));
+
+    if (!currentCenter || currentZoom == null) {
+      return;
+    }
+
+    const targetXRatio = this.clamp(options.targetXRatio ?? 0.5, 0, 1);
+    const targetYRatio = this.clamp(options.targetYRatio ?? 0.5, 0, 1);
+    const coordinate = fromLonLat([location.lon, location.lat]);
+
+    view.setZoom(nextZoom);
+    view.centerOn(coordinate, size, [size[0] * targetXRatio, size[1] * targetYRatio]);
+    const targetCenter = view.getCenter();
+    view.setCenter(currentCenter);
+    view.setZoom(currentZoom);
+
+    if (!targetCenter) {
+      return;
+    }
+
+    view.animate({
+      center: targetCenter,
+      zoom: nextZoom,
+      duration: options.duration ?? 350,
+    });
+  }
+
   private readonly onMapClick = (event: unknown) => {
     if (!this.map) return;
     if (!this.isMapClickEvent(event)) return;
@@ -233,6 +281,10 @@ export class AssignmentMap implements AfterViewInit, OnDestroy, OnChanges {
 
     const maybePixel = (event as { pixel?: unknown }).pixel;
     return Array.isArray(maybePixel) && maybePixel.length === 2;
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
<!--
  Thanks for contributing 🙌
  Please fill out as much of this template as makes sense for your change.
-->

## 📋 Description

<!-- A concise explanation of **what** this PR does and **why**.
     If this addresses an open issue, link it with “Fixes #123”. -->

Implemented map marker interactions.

- When clicking a marker on the map the corresponding assignment is highlighted in the bottom sheet list. 
- The list is automatically scrolled to the correct assignment, so that it is visible in the top of the list (except for last assignments in the list)
- The assignment card is highlighted with an animation that "pops out of the list for a second" and a border around the assignment card. The border is permanent until the user interacts with the map, bottom sheet or list again.  

## 🔗 Related issue(s) / PR(s)

Closes #52 
Related  to #49 

## 🧰 Type of change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [x] Code compiles & passes existing tests
- [x] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [x] Follows project coding style / guidelines
- [x] No new ESLint/TSLint/SwiftLint/etc. warnings
- [x] Tested on all supported browsers / OSs / platforms

## 📝 Implementation notes

Right now the map zooms in on the clicked marker on the map. When the route line between markers is implemented later, it might be better to zoom in on the line between the two assignments, showing both assignments in the map.


## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀
