### PR TITLE
116 fix mini assignment card   update view directions to show route in app map

### DIFF
--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -25,7 +25,7 @@
     "loading": "Loading assignment...",
     "notFound": "Assignment not found.",
     "back": "Back",
-    "showDirections": "Show directions",
+    "showDirections": "Open in Google Maps",
     "expandMap": "Expand map",
     "description": "Description",
     "contactDetails": "Contact details",

--- a/public/assets/i18n/no.json
+++ b/public/assets/i18n/no.json
@@ -25,7 +25,7 @@
     "loading": "Laster oppdrag...",
     "notFound": "Fant ikke oppdraget.",
     "back": "Tilbake",
-    "showDirections": "Vis veibeskrivelse",
+    "showDirections": "Åpne i Google Maps",
     "expandMap": "Utvid kart",
     "description": "Beskrivelse",
     "contactDetails": "Kontaktdetaljer",

--- a/src/app/features/dashboard/components/mini-assignment-card/mini-assignment-card.spec.ts
+++ b/src/app/features/dashboard/components/mini-assignment-card/mini-assignment-card.spec.ts
@@ -84,23 +84,19 @@ describe('MiniAssignmentCard', () => {
     expect(spy).toHaveBeenCalledWith('123');
   });
 
-  it('should stop propagation and open Google Maps when directions button is clicked', () => {
+  it('should stop propagation and emit directionsClick when directions button is clicked', () => {
     const stopPropagation = vi.fn();
     const event = { stopPropagation } as unknown as MouseEvent;
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const directionsClickSpy = vi.spyOn(component.directionsClick, 'emit');
 
     component.onDirectionsClick(event);
 
     expect(stopPropagation).toHaveBeenCalled();
-    expect(windowOpenSpy).toHaveBeenCalledWith(
-      'https://www.google.com/maps/dir/?api=1&destination=Kl%C3%B8buvegen%20179%2C%207031%20Trondheim',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    expect(directionsClickSpy).toHaveBeenCalledWith(mockAssignment);
   });
 
-  it('should open Google Maps when directions button in template is clicked', () => {
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  it('should emit directionsClick when directions button in template is clicked', () => {
+    const directionsClickSpy = vi.spyOn(component.directionsClick, 'emit');
 
     const buttons = fixture.debugElement.queryAll(By.css('button'));
     const directionsButton = buttons[1];
@@ -112,23 +108,19 @@ describe('MiniAssignmentCard', () => {
     directionsButton.triggerEventHandler('click', clickEvent);
 
     expect(clickEvent.stopPropagation).toHaveBeenCalled();
-    expect(windowOpenSpy).toHaveBeenCalledWith(
-      'https://www.google.com/maps/dir/?api=1&destination=Kl%C3%B8buvegen%20179%2C%207031%20Trondheim',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    expect(directionsClickSpy).toHaveBeenCalledWith(mockAssignment);
   });
 
   it('should not fail if assignment is missing in onDirectionsClick', () => {
     const stopPropagation = vi.fn();
     const event = { stopPropagation } as unknown as MouseEvent;
-    const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const directionsClickSpy = vi.spyOn(component.directionsClick, 'emit');
 
     (component as { assignment?: Assignment }).assignment = undefined;
 
     expect(() => component.onDirectionsClick(event)).not.toThrow();
     expect(stopPropagation).toHaveBeenCalled();
-    expect(windowOpenSpy).not.toHaveBeenCalled();
+    expect(directionsClickSpy).not.toHaveBeenCalled();
   });
 
   it('should show completed status label when assignment status is completed', () => {

--- a/src/app/features/dashboard/components/mini-assignment-card/mini-assignment-card.ts
+++ b/src/app/features/dashboard/components/mini-assignment-card/mini-assignment-card.ts
@@ -73,11 +73,6 @@ export class MiniAssignmentCard {
 
     if (!this.assignment) return;
 
-    const destination = encodeURIComponent(this.assignment.address);
-    window.open(
-      `https://www.google.com/maps/dir/?api=1&destination=${destination}`,
-      '_blank',
-      'noopener,noreferrer',
-    );
+    this.directionsClick.emit(this.assignment);
   }
 }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.html
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.html
@@ -53,6 +53,7 @@
               <app-mini-assignment-card
                 [assignment]="assignment"
                 (cardClick)="goToAssignmentDetails($event)"
+                (directionsClick)="onMiniAssignmentDirectionsClick($event)"
               />
             </div>
           }

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.spec.ts
@@ -377,6 +377,28 @@ describe('DashboardPage', () => {
     );
   });
 
+  it('should reuse marker click flow when mini card directions is clicked', () => {
+    const markerClickSpy = vi.spyOn(component, 'onMarkerClicked');
+
+    component.onMiniAssignmentDirectionsClick(MOCK_CARDS[1]);
+
+    expect(markerClickSpy).toHaveBeenCalledWith(component.mapAssignments[1]);
+  });
+
+  it('should build fallback map assignment when mini card is missing from mapAssignments', () => {
+    const markerClickSpy = vi.spyOn(component, 'onMarkerClicked');
+    component.mapAssignments = [];
+
+    component.onMiniAssignmentDirectionsClick(MOCK_CARDS[2]);
+
+    expect(markerClickSpy).toHaveBeenCalledWith({
+      id: '3',
+      name: 'Kommende oppdrag',
+      location: { lat: 63.4105, lon: 10.3772 },
+      description: 'Adresse 3, 7021 Trondheim',
+    });
+  });
+
   it('should clear the active route segment when the selected day changes', () => {
     component.activeRouteSegmentId = buildRouteSegmentId('assignment-1', 'assignment-2');
 

--- a/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/features/dashboard/pages/dashboard-page/dashboard-page.ts
@@ -163,6 +163,29 @@ export class DashboardPage implements OnInit, OnDestroy {
     this.scrollToAssignmentCard(assignmentId);
   }
 
+  onMiniAssignmentDirectionsClick(assignment: Assignment): void {
+    const matchingMapAssignment = this.mapAssignments.find(
+      (mapAssignment) => String(mapAssignment.id) === assignment.id,
+    );
+
+    if (matchingMapAssignment) {
+      this.onMarkerClicked(matchingMapAssignment);
+      return;
+    }
+
+    const location = this.toMapLocation(assignment);
+    if (!location) {
+      return;
+    }
+
+    this.onMarkerClicked({
+      id: assignment.id,
+      name: assignment.title,
+      location,
+      description: assignment.address,
+    });
+  }
+
   onViewChange(listView: boolean) {
     this.isListView = listView;
     if (listView) {


### PR DESCRIPTION
<!--
  Thanks for contributing 🙌
  Please fill out as much of this template as makes sense for your change.
-->

## 📋 Description

<!-- A concise explanation of **what** this PR does and **why**.
     If this addresses an open issue, link it with “Fixes #123”. -->

View direction-button in mini assignment card now highlights to route from previous assignment to corresponding assignment instead of opening Google Maps. Also text in assignment details page (address component) says: "open In Google Maps"  instead of view directions.

## 🔗 Related issue(s) / PR(s)

Closes #116 

## 🧰 Type of change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [ ] Code compiles & passes existing tests
- [ ] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [ ] Follows project coding style / guidelines
- [ ] No new ESLint/TSLint/SwiftLint/etc. warnings
- [ ] Tested on all supported browsers / OSs / platforms



## 📸 Screenshots / GIFs (if UI change)

<!-- Drag in images or paste links -->
<img width="453" height="669" alt="image" src="https://github.com/user-attachments/assets/d3a9007e-af70-4f21-9bb2-48a3f9bf807b" />

<img width="460" height="690" alt="image" src="https://github.com/user-attachments/assets/8155274e-b73a-4777-8132-1857ac24e313" />


## 👥 Reviewer checklist (maintainer use)

- [ ] PR title & description are clear
- [ ] Commit history is tidy (squashed / labelled appropriately)
- [ ] All CI checks pass
- [ ] Labels & milestone applied
- [ ] Ready to merge 🚀
