### PR TITLE
128 assignment details make back button stickyfloating

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,0 +1,12 @@
+.app-navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 60;
+}
+
+.app-content {
+  min-height: 100dvh;
+  padding-top: 4rem;
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,2 +1,5 @@
-<app-navbar />
-<router-outlet />
+<app-navbar class="app-navbar" />
+
+<main class="app-content">
+  <router-outlet />
+</main>

--- a/src/app/core/layout/navbar/navbar.css
+++ b/src/app/core/layout/navbar/navbar.css
@@ -1,11 +1,4 @@
 :host {
   display: block;
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  transition: transform 300ms ease;
-}
-
-:host.navbar-hidden {
-  transform: translateY(-100%);
+  width: 100%;
 }

--- a/src/app/core/layout/navbar/navbar.spec.ts
+++ b/src/app/core/layout/navbar/navbar.spec.ts
@@ -55,7 +55,6 @@ describe('Navbar', () => {
     expect(component.menuOpen).toBe(false);
     expect(component.darkMode).toBe(false);
     expect(component.currentLang).toBe('no');
-    expect(component.isHidden).toBe(false);
   });
 
   // ── Logo ──
@@ -176,38 +175,6 @@ describe('Navbar', () => {
 
     expect(component.currentLang).toBeTruthy();
     expect(localStorageSetItemSpy).not.toHaveBeenCalled();
-  });
-
-  it('should hide navbar on scroll down and show on scroll up', () => {
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(100);
-    component.onScroll();
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(200);
-    component.onScroll();
-    expect(component.isHidden).toBe(true);
-
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(180);
-    component.onScroll();
-    expect(component.isHidden).toBe(false);
-  });
-
-  it('should not hide navbar when near the top of the page', () => {
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(0);
-    component.onScroll();
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(50);
-    component.onScroll();
-    expect(component.isHidden).toBe(false);
-  });
-
-  it('should ignore scroll deltas smaller than threshold', () => {
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(100);
-    component.onScroll();
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(200);
-    component.onScroll();
-    expect(component.isHidden).toBe(true);
-
-    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(195);
-    component.onScroll();
-    expect(component.isHidden).toBe(true);
   });
 
   // ── Cleanup ──

--- a/src/app/core/layout/navbar/navbar.ts
+++ b/src/app/core/layout/navbar/navbar.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, HostListener, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
 import { DrawerModule } from 'primeng/drawer';
@@ -27,22 +27,6 @@ export class Navbar {
   private router = inject(Router);
   private translate = inject(TranslateService);
   private themeService = inject(ThemeService);
-
-  // Toggles 'navbar-hidden' class on host element to hide/show navbar
-  @HostBinding('class.navbar-hidden')
-  isHidden = false;
-
-  private lastScrollY = 0;
-  private scrollThreshold = 10;
-
-  @HostListener('window:scroll')
-  onScroll() {
-    const currentScrollY = window.scrollY;
-    const delta = currentScrollY - this.lastScrollY;
-    if (Math.abs(delta) < this.scrollThreshold) return;
-    this.isHidden = delta > 0 && currentScrollY > 64;
-    this.lastScrollY = currentScrollY;
-  }
 
   get currentLang() {
     return this.translate.currentLang ?? this.translate.defaultLang;

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.css
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.css
@@ -80,6 +80,68 @@
   gap: 0.5rem;
 }
 
+.details-map-overlay {
+  pointer-events: none;
+}
+
+.details-map-overlay-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: min(16.5rem, calc(100vw - 5.5rem));
+}
+
+.details-map-address {
+  pointer-events: none;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.details-map-street {
+  line-height: 1.2;
+}
+
+.details-map-directions {
+  pointer-events: auto;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.details-map-directions-compact {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.details-map-directions-full {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .details-map-overlay-card {
+    width: auto;
+    min-width: 18rem;
+    max-width: 28rem;
+  }
+
+  .details-map-street {
+    font-size: 0.95rem;
+  }
+
+  .details-map-directions-compact {
+    display: none;
+  }
+
+  .details-map-directions-full {
+    display: inline-flex;
+  }
+}
+
 @media (min-width: 640px) {
   .notes-action-row {
     align-items: flex-start;

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.css
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.css
@@ -1,3 +1,79 @@
+.assignment-details-shell {
+  position: relative;
+  padding-top: 4.25rem;
+}
+
+.details-back-fab {
+  position: fixed;
+  top: 4.75rem;
+  left: 1rem;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 45;
+  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 255, 255, 0.12) 0%,
+    rgba(255, 255, 255, 0.02) 60%,
+    rgba(255, 255, 255, 0.06) 100%
+  );
+  backdrop-filter: blur(24px) saturate(150%);
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
+  border: 1.5px solid rgba(255, 255, 255, 0.25);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.08),
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    inset 0 2px 4px rgba(255, 255, 255, 0.25),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.05);
+
+  color: var(--fab-fg);
+}
+
+.details-back-fab i {
+  font-size: 1.2rem;
+}
+
+.details-back-fab:hover {
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 255, 255, 0.2) 0%,
+    rgba(255, 255, 255, 0.05) 60%,
+    rgba(255, 255, 255, 0.1) 100%
+  );
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.12),
+    0 4px 12px rgba(0, 0, 0, 0.06),
+    inset 0 2px 6px rgba(255, 255, 255, 0.35),
+    inset 0 -1px 3px rgba(0, 0, 0, 0.08);
+  transform: scale(1.06);
+}
+
+.details-back-fab:active {
+  transform: scale(0.95);
+}
+
+.details-back-fab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+@media (min-width: 768px) {
+  .assignment-details-shell {
+    padding-top: 4.5rem;
+  }
+
+  .details-back-fab {
+    left: 1.5rem;
+  }
+}
+
 .notes-action-row {
   display: flex;
   flex-direction: column;

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
@@ -15,24 +15,22 @@
       ></button>
     </div>
   } @else if (assignment) {
-    <div class="mx-auto max-w-6xl p-4 md:p-6">
-      <!-- Top bar -->
-      <div class="mb-4 flex items-center gap-3">
-        <button
-          pButton
-          type="button"
-          [label]="'assignment.back' | translate"
-          icon="pi pi-arrow-left"
-          severity="secondary"
-          class="theme-secondary-button shrink-0 rounded-lg"
-          (click)="goBack()"
-          aria-label="tilbake-knapp"
-        ></button>
+    <div class="assignment-details-shell mx-auto max-w-6xl p-4 md:p-6">
+      <button
+        type="button"
+        class="details-back-fab"
+        (click)="goBack()"
+        [attr.aria-label]="'assignment.back' | translate"
+      >
+        <i class="pi pi-arrow-left" aria-hidden="true"></i>
+      </button>
 
-        <p class="text-theme-primary min-w-0 truncate text-xl font-semibold md:text-2xl">
-          {{ 'assignment.detailsTitle' | translate }}
-        </p>
-      </div>
+      <p
+        class="text-theme-primary mb-4 min-w-0 truncate text-xl font-semibold md:text-2xl"
+        data-testid="assignment-details-title"
+      >
+        {{ 'assignment.detailsTitle' | translate }}
+      </p>
 
       <!-- Map section -->
       <section class="surface-1 overflow-hidden rounded-2xl shadow-sm">

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
@@ -42,35 +42,41 @@
             (markerClicked)="onMarkerClicked($event)"
           ></app-assignment-map>
 
-          <div class="surface-overlay absolute right-4 top-4 z-20 rounded-2xl p-3 shadow-md">
-            <div class="text-theme-primary text-base font-semibold">
-              {{ assignment.streetAddress }}
-            </div>
-            <div class="text-theme-secondary text-sm">
-              {{ assignment.municipalityName }}
-            </div>
+          <div class="details-map-overlay absolute right-3 top-3 z-20 md:right-4 md:top-4">
+            <div class="details-map-overlay-card surface-overlay rounded-2xl p-2 shadow-md">
+              <div class="details-map-address min-w-0">
+                <i class="pi pi-map-marker text-theme-primary text-sm" aria-hidden="true"></i>
+                <div class="min-w-0">
+                  <div class="text-theme-primary details-map-street truncate text-sm font-semibold">
+                    {{ assignment.streetAddress }}
+                  </div>
+                  <div class="text-theme-secondary truncate text-xs">
+                    {{ assignment.municipalityName }}
+                  </div>
+                </div>
+              </div>
 
-            <button
-              pButton
-              type="button"
-              [label]="'assignment.showDirections' | translate"
-              icon="pi pi-directions"
-              severity="secondary"
-              class="theme-secondary-button mt-3 rounded-full"
-              (click)="openDirections()"
-              [attr.aria-label]="'assignment.showDirections' | translate"
-            ></button>
-          </div>
+              <button
+                pButton
+                type="button"
+                icon="pi pi-directions"
+                severity="secondary"
+                class="theme-secondary-button details-map-directions details-map-directions-compact rounded-full"
+                (click)="openDirections()"
+                [attr.aria-label]="'assignment.showDirections' | translate"
+              ></button>
 
-          <div class="absolute bottom-4 right-4 z-20">
-            <button
-              pButton
-              type="button"
-              icon="pi pi-expand"
-              severity="secondary"
-              [rounded]="true"
-              [attr.aria-label]="'assignment.expandMap' | translate"
-            ></button>
+              <button
+                pButton
+                type="button"
+                [label]="'assignment.showDirections' | translate"
+                icon="pi pi-directions"
+                severity="secondary"
+                class="theme-secondary-button details-map-directions details-map-directions-full rounded-full"
+                (click)="openDirections()"
+                [attr.aria-label]="'assignment.showDirections' | translate"
+              ></button>
+            </div>
           </div>
         </div>
 
@@ -94,7 +100,7 @@
             </h1>
 
             <p class="text-theme-secondary mt-2 text-lg">
-              {{ assignment.date }} • {{ assignment.startTime }}
+              {{ assignment.date }} <br> {{ assignment.startTime }}
               @if (assignment.endTime) {
                 - {{ assignment.endTime }}
               }

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.html
@@ -100,7 +100,8 @@
             </h1>
 
             <p class="text-theme-secondary mt-2 text-lg">
-              {{ assignment.date }} <br> {{ assignment.startTime }}
+              {{ assignment.date }} <br />
+              {{ assignment.startTime }}
               @if (assignment.endTime) {
                 - {{ assignment.endTime }}
               }

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.spec.ts
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.spec.ts
@@ -110,7 +110,9 @@ describe('AssignmentDetailsPage', () => {
   it('should render a title in the top bar', async () => {
     await createComponent('1315598');
 
-    const topBarTitle = fixture.nativeElement.querySelector('.mb-4 p');
+    const topBarTitle = fixture.nativeElement.querySelector(
+      '[data-testid="assignment-details-title"]',
+    );
 
     expect(topBarTitle?.textContent).toContain('assignment.detailsTitle');
   });

--- a/src/app/features/assignment-details/pages/assignment-details/assignment-details.ts
+++ b/src/app/features/assignment-details/pages/assignment-details/assignment-details.ts
@@ -46,6 +46,8 @@ export class AssignmentDetailsPage implements OnInit {
   private readonly noteSaveDelayMs = 500;
 
   ngOnInit(): void {
+    this.resetScrollPosition();
+
     const id = this.route.snapshot.paramMap.get('id');
 
     if (!id) {
@@ -64,6 +66,12 @@ export class AssignmentDetailsPage implements OnInit {
         this.updateMapAssignments();
         this.loadPersonalNote();
       });
+  }
+
+  private resetScrollPosition(): void {
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
   }
 
   goBack(): void {


### PR DESCRIPTION
<!--
  Thanks for contributing 🙌
  Please fill out as much of this template as makes sense for your change.
-->

## 📋 Description

<!-- A concise explanation of **what** this PR does and **why**.
     If this addresses an open issue, link it with “Fixes #123”. -->

Made the back button in assignment details page float in the top left position, when scrolling down it is now always visible and available for clicking. Also refactored style so that it now looks like the toggle map/list- view from dashboard page (Liquid Glass). Also the bug with the page not being in top position when entering is now fixed. So the page always starts in top position when clicking on an assignment. 

Also the address/view directions overlay on the map is now smaller and more responsive for smaller mobile devices. 

## 🔗 Related issue(s) / PR(s)

<!-- e.g. Closes #123, Depends on #456, etc. -->

Closes #128 
Closes #133 

## 🧰 Type of change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor / tech debt
- [ ] 📝 Documentation only
- [ ] ⚠️ Breaking change
- [ ] 🔒 Security fix
- [ ] 🚦 CI / tooling

## ✅ Acceptance criteria

- [x] Code compiles & passes existing tests
- [x] New / updated tests added
- [ ] Documentation updated (README, comments, wiki)
- [x] Follows project coding style / guidelines
- [ ] No new ESLint/TSLint/SwiftLint/etc. warnings
- [ ] Tested on all supported browsers / OSs / platforms

## 📝 Implementation notes

<!-- Anything reviewers should know about peculiar decisions, trade-offs, etc. -->

## 📸 Screenshots / GIFs (if UI change)

<img width="370" height="666" alt="image" src="https://github.com/user-attachments/assets/086bca1f-df44-4e7f-a89b-2a81c90f634a" />


## 👥 Reviewer checklist (maintainer use)

- [x] PR title & description are clear
- [x] Commit history is tidy (squashed / labelled appropriately)
- [x] All CI checks pass
- [x] Labels & milestone applied
- [x] Ready to merge 🚀
